### PR TITLE
Documentation Typo Fix: start_char description in the span API

### DIFF
--- a/website/docs/api/span.jade
+++ b/website/docs/api/span.jade
@@ -25,7 +25,7 @@ p A slice from a #[code Doc] object.
     +row
         +cell #[code start_char]
         +cell int
-        +cell The character offset for the end of the span.
+        +cell The character offset for the start of the span.
 
     +row
         +cell #[code end_char]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title -->
Fix the typo in the `start_char` description of the span API in the documentation.
It explains the `end` of the span as the `start_char` description.
This commit fixed this description to the `end` of the span.

## Description
<!--- Use this section to describe your changes and how they're affecting the code. -->
<!-- If your changes required testing, include information about the testing environment and the tests you ran. -->
This pull request contains a typo fix in the documentation only.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all applicable boxes.: -->
- [ ] **Bug fix** (non-breaking change fixing an issue)
- [ ] **New feature** (non-breaking change adding functionality to spaCy)
- [ ] **Breaking change** (fix or feature causing change to spaCy's existing functionality)
- [x] **Documentation** (addition to documentation of spaCy)

## Checklist:
<!--- Go over all the following points, and put an `x` in all applicable boxes.: -->
- [ ] My change requires a change to spaCy's documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
